### PR TITLE
Support other OS and Disable native stacktraces when libunwind is not installed on the system

### DIFF
--- a/.github/actions/build-and-run/action.yml
+++ b/.github/actions/build-and-run/action.yml
@@ -24,7 +24,12 @@ runs:
         trap 'cat log.txt; exit 1' err;
           
         cat log.txt | grep -P 'Caught a Segmentation Fault \[pid=\d+\]' > /dev/null;
-        cat log.txt | grep -P '\[pc=0x.+, sp=0x.+\] in .+' > /dev/null;
+        if [[ "{{ inputs.IMAGE }}" == *-no-libunwind ]]
+        then
+          cat log.txt | grep -P '\[pc=0x.+, sp=0x.+\] in .+' > /dev/null;
+        else
+          cat log.txt | grep -P '^Cannot unwind stacktraces: .+' > /dev/null;
+        fi
         cat log.txt | grep -P 'at main \(.+\)' > /dev/null;
         cat log.txt | grep -P 'at foo \(.+\)' > /dev/null;
         cat log.txt | grep -P 'at bar \(.+\)' > /dev/null;
@@ -32,5 +37,4 @@ runs:
         trap - err;
       shell: bash  
       
-
     

--- a/.github/actions/build-and-run/action.yml
+++ b/.github/actions/build-and-run/action.yml
@@ -24,7 +24,7 @@ runs:
         trap 'cat log.txt; exit 1' err;
           
         cat log.txt | grep -P 'Caught a Segmentation Fault \[pid=\d+\]' > /dev/null;
-        if [[ "{{ inputs.IMAGE }}" == *-no-libunwind ]]
+        if [[ "${{ inputs.IMAGE }}" == *-no-libunwind ]]
         then
           cat log.txt | grep -P '^Cannot unwind stacktraces: .+' > /dev/null;
         else

--- a/.github/actions/build-and-run/action.yml
+++ b/.github/actions/build-and-run/action.yml
@@ -26,9 +26,9 @@ runs:
         cat log.txt | grep -P 'Caught a Segmentation Fault \[pid=\d+\]' > /dev/null;
         if [[ "{{ inputs.IMAGE }}" == *-no-libunwind ]]
         then
-          cat log.txt | grep -P '\[pc=0x.+, sp=0x.+\] in .+' > /dev/null;
-        else
           cat log.txt | grep -P '^Cannot unwind stacktraces: .+' > /dev/null;
+        else
+          cat log.txt | grep -P '\[pc=0x.+, sp=0x.+\] in .+' > /dev/null;
         fi
         cat log.txt | grep -P 'at main \(.+\)' > /dev/null;
         cat log.txt | grep -P 'at foo \(.+\)' > /dev/null;

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['14.17.0', '12.16.3', '12.20.0']
-        image: ['alpine', 'base']
+        image: ['alpine', 'base', 'base-no-libunwind']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['14.17.0', '12.16.3', '12.20.0']
-        image: ['alpine', 'base']
+        image: ['alpine', 'base', 'base-no-libunwind']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['14.17.0', '12.16.3', '12.20.0']
-        image: ['alpine', 'base']
+        image: ['alpine', 'base', 'base-no-libunwind']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ A C++ Node.js module that helps gathering informations on segmentation fault
 |:-----:|:------------:|:-------:|:-----:|
 | ✅    | ✅           |     ❓  | ❓    |
 
-## Install
+## Installation
 
-`npm install node-segfault-handler`
+### Node.js
+```
+npm install node-segfault-handler
+```
 ## Requirements
 
 This lib requires `libunwind-dev` to work

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A C++ Node.js module that helps gathering informations on segmentation fault
 |:-----:|:------------:|:-------:|:-----:|
 | ✅    | ✅           |     ❓  | ❓    |
 
+## Install
+
+`npm install node-segfault-handler`
 ## Requirements
 
 This lib requires `libunwind-dev` to work
@@ -15,7 +18,7 @@ This lib requires `libunwind-dev` to work
 ## Usage
 
 ```js
-let segfaultHandler = require('segfault-handler');
+let segfaultHandler = require('node-segfault-handler');
 
 /**
  * Once a segfault occurs, 
@@ -31,7 +34,7 @@ segfaultHandler.segfault();
 ## Example
 
 ```js
-let segfaultHandler = require(`segfault-handler`);
+let segfaultHandler = require('node-segfault-handler');
 
 function foo() {
   bar();

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,7 +21,8 @@
         }],
         [ 'OS!="linux"', {
           "defines": [
-            "__V8__"
+            "__V8__",
+            "USE_LIBUNWIND=0"
           ]
         }]
       ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "targets": [
     {
-      "target_name": "SegfaultHandler",
+      "target_name": "NodeSegfaultHandler",
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "includes"
@@ -12,8 +12,14 @@
       "conditions": [
         [ 'OS=="linux"', {
           "libraries": [
-            "-lunwind"
+            "<!(python3 -c 'from ctypes.util import find_library;print(find_library(\"unwind\")!=None and \"-lunwind\" or \"\")')"
           ],
+          "defines": [
+            "__V8__",
+            "<!(python3 -c 'from ctypes.util import find_library;print(find_library(\"unwind\")!=None and \"USE_LIBUNWIND=1\" or \"USE_LIBUNWIND=0\")')"
+          ]
+        }],
+        [ 'OS!="linux"', {
           "defines": [
             "__V8__"
           ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,11 +12,11 @@
       "conditions": [
         [ 'OS=="linux"', {
           "libraries": [
-            "<!(python3 -c 'from ctypes.util import find_library;print(find_library(\"unwind\")!=None and \"-lunwind\" or \"\")')"
+            "<!(python -c 'from ctypes.util import find_library;print(find_library(\"unwind\")!=None and \"-lunwind\" or \"\")')"
           ],
           "defines": [
             "__V8__",
-            "<!(python3 -c 'from ctypes.util import find_library;print(find_library(\"unwind\")!=None and \"USE_LIBUNWIND=1\" or \"USE_LIBUNWIND=0\")')"
+            "<!(python -c 'from ctypes.util import find_library;print(find_library(\"unwind\")!=None and \"USE_LIBUNWIND=1\" or \"USE_LIBUNWIND=0\")')"
           ]
         }],
         [ 'OS!="linux"', {

--- a/docker/images/base-no-libunwind/Dockerfile
+++ b/docker/images/base-no-libunwind/Dockerfile
@@ -1,0 +1,20 @@
+ARG NODE_VERSION=12.16.3
+FROM node:${NODE_VERSION}
+
+RUN  set -x \
+  && apt update \
+  && apt install -y .gyp \
+      python \
+      make \
+      g++
+
+ADD . /var/app
+ADD ./docker/scripts/entrypoint.sh /bin/entrypoint
+
+WORKDIR /var/app
+
+RUN npm install --unsafe-perm
+RUN chmod +x /bin/entrypoint
+
+ENTRYPOINT [ "/bin/entrypoint" ]
+CMD ["node", "tests/test.js"]

--- a/includes/backtrace.hpp
+++ b/includes/backtrace.hpp
@@ -8,7 +8,9 @@
 #include <cxxabi.h>
 
 #define UNW_LOCAL_ONLY
+#if USE_LIBUNWIND==1
 #include <libunwind.h>
+#endif
 
 #ifdef __V8__
   #include <nan.h>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-let segfaultHandler = require('bindings')('SegfaultHandler');
+let segfaultHandler = require('bindings')('NodeSegfaultHandler');
 
 module.exports = {
     registerHandler: segfaultHandler.registerHandler,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "segfault-handler",
-  "version": "1.0.0",
+  "name": "node-segfault-handler",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "segfault-handler",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "node-segfault-handler",
+      "version": "1.0.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "bindings": "^1.5.0",
         "nan": "^2.15.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "segfault-handler",
+  "name": "node-segfault-handler",
   "version": "1.0.0",
   "description": "A C++ Node.js module that helps gathering informations on segmentation fault",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A C++ Node.js module that helps gathering informations on segmentation fault",
   "main": "index.js",
   "keywords": ["linux", "alpine-linux", "segfault", "libunwind"],
@@ -20,5 +20,11 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.15.0"
-  }
+  },
+  "files": [
+    "index.js",
+    "src/*",
+    "includes/*",
+    "binding.gyp"
+  ]
 }

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -4,38 +4,42 @@
  * Print native stack trace of current thread.
  */
 void Backtrace::PrintNative() {
-  unw_cursor_t cursor;
-  unw_context_t context;
+  #if USE_LIBUNWIND==1
+    unw_cursor_t cursor;
+    unw_context_t context;
 
-  // print out all the frames to stderr
-  // Initialize cursor to current frame for local unwinding.
-  unw_getcontext(&context);
-  unw_init_local(&cursor, &context);
+    // print out all the frames to stderr
+    // Initialize cursor to current frame for local unwinding.
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
 
-  // Unwind frames one by one, going up the frame stack.
-  while (unw_step(&cursor))
-  {
-    unw_word_t offset, instruction_pointer, stack_pointer;
-
-    unw_get_reg(&cursor, UNW_REG_IP, &instruction_pointer);
-    unw_get_reg(&cursor, UNW_REG_SP, &stack_pointer);
-
-    fprintf(stderr, "[pc=0x%016lx, sp=0x%016lx] ", instruction_pointer, stack_pointer);
-
-    char symbol_name[256] = {"<unknown symbol>"};
-    char *name = symbol_name;
-    if (unw_get_proc_name(&cursor, symbol_name, sizeof(symbol_name), &offset) == 0)
+    // Unwind frames one by one, going up the frame stack.
+    while (unw_step(&cursor))
     {
-      int status = 0;
-      // If cannot demangle name, use the symbol name
-      if ((name = abi::__cxa_demangle(symbol_name, NULL, NULL, &status)) == 0)
-      { // Failed to demangle symbol_name
-        name = symbol_name;
-      }
-    }
+      unw_word_t offset, instruction_pointer, stack_pointer;
 
-    fprintf(stderr, "in %s+0x%lx\n", name, offset);
-  }
+      unw_get_reg(&cursor, UNW_REG_IP, &instruction_pointer);
+      unw_get_reg(&cursor, UNW_REG_SP, &stack_pointer);
+
+      fprintf(stderr, "[pc=0x%016lx, sp=0x%016lx] ", instruction_pointer, stack_pointer);
+
+      char symbol_name[256] = {"<unknown symbol>"};
+      char *name = symbol_name;
+      if (unw_get_proc_name(&cursor, symbol_name, sizeof(symbol_name), &offset) == 0)
+      {
+        int status = 0;
+        // If cannot demangle name, use the symbol name
+        if ((name = abi::__cxa_demangle(symbol_name, NULL, NULL, &status)) == 0)
+        { // Failed to demangle symbol_name
+          name = symbol_name;
+        }
+      }
+
+      fprintf(stderr, "in %s+0x%lx\n", name, offset);
+    }
+  #else
+    fprintf(stderr, "Cannot unwind stacktraces: Feature disabled / Missing libunwind on your system\n");
+  #endif
 }
 
 #ifdef __V8__ 


### PR DESCRIPTION
## What does this PR do ?
- This PR allows the module to be compiled on systems that doesn't have the `libunwind` installed, when that's the case the native stacktraces wont be printed and a message explaining why will be printed instead, Javascript stacktraces from V8 will still be printed as the library does not depends on `libunwind` to show them.
- This PR allows `node-segfault-handler` to be compiled on other OS (`Windows`,  `MacOS`, ...) by disabling the compilation with the libunwind. This does not affect the capability of the library to print Javascript stacktraces from V8.