### PR TITLE
Fix compilation on Windows

### DIFF
--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: ['14.17.0', '12.16.3', '12.20.0']
+        node-version: ['14.17.0', '16.15.1', '12.20.0']
         image: ['alpine', 'base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: ['14.17.0', '16.15.1', '12.20.0']
+        node-version: ['14.17.0', '16.16.0', '12.20.0']
         image: ['alpine', 'base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: ['14.17.0', '16.16.0', '12.20.0']
+        node-version: ['14.17.0', '16.13.0', '12.20.0']
         image: ['alpine', 'base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A C++ Node.js module that helps gathering informations on segmentation fault
 
 | Linux | Linux Alpine | Windows | MacOS |
 |:-----:|:------------:|:-------:|:-----:|
-| ✅    | ✅           |      ❓ | ✅    |
+| ✅    | ✅           |      ✅ | ✅    |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A C++ Node.js module that helps gathering informations on segmentation fault
 
 | Linux | Linux Alpine | Windows | MacOS |
 |:-----:|:------------:|:-------:|:-----:|
-| ✅    | ✅           |      ✅ | ✅    |
+| ✅    | ✅           |      ❓ | ✅    |
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,8 @@
 {
   "name": "node-segfault-handler",
   "version": "1.0.4",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "node-segfault-handler",
-      "version": "1.0.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.15.0"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
-    "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
-    }
-  },
   "dependencies": {
     "bindings": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A C++ Node.js module that helps gathering informations on segmentation fault",
   "main": "index.js",
   "keywords": [

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -1,5 +1,18 @@
 #include "backtrace.hpp"
 
+#ifdef NATIVE_STACKTRACE
+char *demangle(char *name) {
+  #if USE_DEMANGLER==DEMANGLER_CXXABI
+    int status = 0;
+    return abi::__cxa_demangle(name, NULL, NULL, &status);
+  #elif USE_DEMANGLER==DEMANGLER_MSVC
+    return name;
+  #else
+    return name;
+  #endif
+}
+#endif // NATIVE_STACKTRACE
+
 /**
  * Print native stack trace of current thread.
  */
@@ -29,7 +42,7 @@ void Backtrace::PrintNative() {
       {
         int status = 0;
         // If cannot demangle name, use the symbol name
-        if ((name = abi::__cxa_demangle(symbol_name, NULL, NULL, &status)) == 0)
+        if ((name = demangle(symbol_name)) == 0)
         { // Failed to demangle symbol_name
           name = symbol_name;
         }

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -6,7 +6,7 @@ char *demangle(char *name) {
     int status = 0;
     return abi::__cxa_demangle(name, NULL, NULL, &status);
   #elif USE_DEMANGLER==DEMANGLER_MSVC
-    return name;
+    return name; // TODO: implement MSVC demangler
   #else
     return name;
   #endif


### PR DESCRIPTION
## What does this PR do ?
Fix compilation issues on windows

- Include `unistd.h` only on unix systems
- On windows include `process.h` and define missing pid_t type
- Compile using the proper c++ demangler based on the platform