### PR TITLE
Fix build error from removed method 'CreationContext()'

### DIFF
--- a/src/segfault-handler.cc
+++ b/src/segfault-handler.cc
@@ -86,7 +86,7 @@ void Segfault(const Nan::FunctionCallbackInfo<v8::Value>& info) {
  */
 void Init(v8::Local<v8::Object> exports) {
   // Create an export context
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context = exports->GetCreationContext().FromMaybe(v8::Local<v8::Context>());
   isolate = context->GetIsolate();
   // Register the functions
   exports->Set(context,


### PR DESCRIPTION
The V8 method `CreationContext()` was deprecated in the version that comes with [Node.js v16](https://github.com/nodejs/node/blob/v16.0.0/deps/v8/include/v8.h#L4280), and was definitely removed starting from [Node.js v19](https://github.com/nodejs/node/blob/v19.0.0/deps/v8/include/v8-object.h#L597). This means that node-segfault-handler does not compile with Node.js >= v19.

Instead, the newer `GetCreationContext()` should be used; it returns a Maybe type which can be unwrapped.

This patch uses `FromMaybe(default_value)` to unwrap the Maybe with a default-constructed context, which is [the same behavior](https://github.com/nodejs/node/blob/v18.0.0/deps/v8/src/api/api.cc#L5067) that the old `CreationContext()` had until the latest Node v18 LTS.