### PR TITLE
Fix deprecated creationcontext from Node 16

### DIFF
--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -13,7 +13,6 @@ jobs:
         image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/build-and-run
@@ -31,7 +30,6 @@ jobs:
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/build-and-run

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -9,8 +9,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0']
-        image: ['alpine', 'base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
+        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/build-and-run
+        with:
+          IMAGE: ${{ matrix.image }} 
+          NODE_VERSION: ${{ matrix.node-version }}
+
+  build-and-run-alpine-images:
+    name: Build and Run ${{ matrix.image }} image - Node.js v${{ matrix.node-version }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpihe3.14', '16.13.0-3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        image: ['alpine']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpihe3.14', '16.13.0-3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
-        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1']
+        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -12,8 +12,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0']
-        image: ['alpine', 'base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
+        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/build-and-run
+        with:
+          IMAGE: ${{ matrix.image }} 
+          NODE_VERSION: ${{ matrix.node-version }}
+
+  build-and-run-alpine-images:
+    name: Build and Run ${{ matrix.image }} image - Node.js v${{ matrix.node-version }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpihe3.14', '16.13.0-3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        image: ['alpine']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
-        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1']
+        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpihe3.14', '16.13.0-3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -16,7 +16,6 @@ jobs:
         image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/build-and-run
@@ -34,7 +33,6 @@ jobs:
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/build-and-run

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
-        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1']
+        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -16,7 +16,6 @@ jobs:
         image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/build-and-run
@@ -30,11 +29,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpihe3.14', '16.13.0-3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/build-and-run

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -10,9 +10,28 @@ jobs:
     name: Build and Run ${{ matrix.image }} image - Node.js v${{ matrix.node-version }}
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0']
-        image: ['alpine', 'base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
+        image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config', 'base-static-linking']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/build-and-run
+        with:
+          IMAGE: ${{ matrix.image }} 
+          NODE_VERSION: ${{ matrix.node-version }}
+
+  build-and-run-alpine-images:
+    name: Build and Run ${{ matrix.image }} image - Node.js v${{ matrix.node-version }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpihe3.14', '16.13.0-3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
+        image: ['alpine']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ On Linux / MacOS you need to have `GCC` or `Clang` installed
 
 On Windows you need to have either `MSVC` or `MinGW` installed
 
-### Linking of libunwind
-| Linux | Linux Alpine | Windows | MacOS |
-|:-----:|:------------:|:-------:|:-----:|
-| Static    | Dynamic           |      None | None    |
-
 ## Platform Specifications
 ### Linux & Linux Alpine
 If the library `libunwind-dev` is installed on your system, the library `node-segfault-handler` will be compiled with it and the native stacktraces will be printed when a segfault occurs.

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,30 +10,30 @@
       "cflags": [ "-O0", "-funwind-tables" ],
       "cflags_cc!": [ "-fno-exceptions" ],
       "variables": {
-        "static_libunwind": "<!(pkg-config --libs libunwind 1>/dev/null 2>/dev/null && echo '-Bstatic -l:libunwind.a -fPIC' || echo '')",
-        "dynamic_libunwind": "<!(pkg-config --libs libunwind 2> /dev/null || echo '')",
-        "use_libunwind": "<!(pkg-config --libs libunwind 1>/dev/null 2>/dev/null && echo 'USE_LIBUNWIND=1' || echo 'USE_LIBUNWIND=0')",
-        "use_musl": "<!(ldd --version 2>&1 | grep musl 1>/dev/null && echo '1' || echo '')"
+        # "static_libunwind": "<!(pkg-config --libs libunwind 1>/dev/null 2>/dev/null && echo '-fPIC -Bstatic -llibunwind' || echo '')",
+        # "dynamic_libunwind": "<!(pkg-config --libs libunwind 2> /dev/null || echo '')",
+        # "use_libunwind": "<!(pkg-config --libs libunwind 1>/dev/null 2>/dev/null && echo 'USE_LIBUNWIND=1' || echo 'USE_LIBUNWIND=0')",
+        # "use_musl": "<!(ldd --version 2>&1 | grep musl 1>/dev/null && echo '1' || echo '')"
       },
       "conditions": [
-        [
-          "use_musl==1", {
-            "libraries": [
-              "<(dynamic_libunwind)"
-            ],
-            "defines": [
-              "__V8__",
-              "<(use_libunwind)"
-            ]
-          }
-        ],
+        # [
+        #   "use_musl==1", {
+        #     "libraries": [
+        #       "<(dynamic_libunwind)"
+        #     ],
+        #     "defines": [
+        #       "__V8__",
+        #       "<(use_libunwind)"
+        #     ]
+        #   }
+        # ],
         [ 'OS=="linux"', {
           "libraries": [
-            "<(static_libunwind)",
+            "<!(pkg-config --libs libunwind 2> /dev/null || echo '')",
           ],
           "defines": [
             "__V8__",
-            "<(use_libunwind)"
+            "<!(pkg-config --libs libunwind 1>/dev/null 2>/dev/null && echo 'USE_LIBUNWIND=1' || echo 'USE_LIBUNWIND=0')"
           ]
         }],
         [ 'OS!="linux"', {

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=12.16.3
 FROM node:${NODE_VERSION}
 
 RUN  set -x \
-  && apk add --no-cache --no-progress --virtual .gyp \
+  && apk add --no-cache --no-progress --virtual gyp \
       python3 \
       make \
       g++ \

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION=12.16.3
-FROM node:${NODE_VERSION}-alpine3.11
+FROM node:${NODE_VERSION}
 
 RUN  set -x \
   && apk add --no-cache --no-progress --virtual .gyp \

--- a/docker/images/base-no-libunwind/Dockerfile
+++ b/docker/images/base-no-libunwind/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}
 
 RUN  set -x \
   && apt update \
-  && apt install -y .gyp \
+  && apt install -y gyp \
       python3 \
       make \
       g++

--- a/docker/images/base-no-pkg-config/Dockerfile
+++ b/docker/images/base-no-pkg-config/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}
 
 RUN  set -x \
   && apt update \
-  && apt install -y .gyp \
+  && apt install -y gyp \
       python3 \
       make \
       g++ \

--- a/docker/images/base-partial-no-libunwind/Dockerfile
+++ b/docker/images/base-partial-no-libunwind/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}
 
 RUN  set -x \
   && apt update \
-  && apt install -y .gyp \
+  && apt install -y gyp \
       python3 \
       make \
       g++ \

--- a/docker/images/base-static-linking/Dockerfile
+++ b/docker/images/base-static-linking/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION} as builder
 
 RUN  set -x \
   && apt update \
-  && apt install -y .gyp \
+  && apt install -y gyp \
       python3 \
       make \
       g++ \

--- a/docker/images/base/Dockerfile
+++ b/docker/images/base/Dockerfile
@@ -3,7 +3,7 @@ FROM node:${NODE_VERSION}
 
 RUN  set -x \
   && apt update \
-  && apt install -y .gyp \
+  && apt install -y gyp \
       python3 \
       make \
       g++ \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "A C++ Node.js module that helps gathering informations on segmentation fault",
   "main": "index.js",
   "keywords": [

--- a/src/segfault-handler.cc
+++ b/src/segfault-handler.cc
@@ -86,7 +86,12 @@ void Segfault(const Nan::FunctionCallbackInfo<v8::Value>& info) {
  */
 void Init(v8::Local<v8::Object> exports) {
   // Create an export context
-  v8::Local<v8::Context> context = exports->GetCreationContext().FromMaybe(v8::Local<v8::Context>());
+  #if NODE_MODULE_VERSION >=93 // Node >=16
+    v8::Local<v8::Context> context = exports->GetCreationContext().FromMaybe(v8::Local<v8::Context>())
+  #else
+    v8::Local<v8::Context> context = exports->CreationContext();
+  #endif
+
   isolate = context->GetIsolate();
   // Register the functions
   exports->Set(context,

--- a/src/segfault-handler.cc
+++ b/src/segfault-handler.cc
@@ -86,7 +86,7 @@ void Segfault(const Nan::FunctionCallbackInfo<v8::Value>& info) {
  */
 void Init(v8::Local<v8::Object> exports) {
   // Create an export context
-  v8::Local<v8::Context> context = exports->CreationContext();
+  v8::Local<v8::Context> context = exports->GetCreationContext().FromMaybe(v8::Local<v8::Context>());
   isolate = context->GetIsolate();
   // Register the functions
   exports->Set(context,

--- a/src/segfault-handler.cc
+++ b/src/segfault-handler.cc
@@ -86,8 +86,8 @@ void Segfault(const Nan::FunctionCallbackInfo<v8::Value>& info) {
  */
 void Init(v8::Local<v8::Object> exports) {
   // Create an export context
-  #if NODE_MODULE_VERSION >=93 // Node >=16
-    v8::Local<v8::Context> context = exports->GetCreationContext().FromMaybe(v8::Local<v8::Context>())
+  #if NODE_MODULE_VERSION >= 93 // Node >=16
+    v8::Local<v8::Context> context = exports->GetCreationContext().FromMaybe(v8::Local<v8::Context>());
   #else
     v8::Local<v8::Context> context = exports->CreationContext();
   #endif


### PR DESCRIPTION
# What does this PR do ?

- Remove deprecated call in Node >= 16
- Rollback to dynamic linking because of libunwind inconsistently compiled with -fPIC
- Do not call programs inside binding-gyp variables because they cannot be made plateform dependent which means other platform than linux may not be able to run the commands which would lead to node-gyp not being able to  compile the library
even though the plateform does not require any of the defined variables.
- Add test for V18
- Only support LTS versions of node, because NAN is not consistent in non LTS versions.