### PR TITLE
Better support for NodeJS versions using Nan methods

### DIFF
--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
         image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
         image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1']
+        node-version: ['12.22.7', '14.18.1', '16.13.0', '18.12.1', '19.3.0']
         image: ['base', 'base-no-libunwind', 'base-partial-no-libunwind', 'base-no-pkg-config']
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16']
+        node-version: ['12.22.12-alpine3.15', '14.18.1-alpine3.14', '16.13.0-alpine3.14', '18.12.1-alpine3.16', '19.3.0-alpine3.17']
         image: ['alpine']
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,37 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.3.0",
-  "lockfileVersion": 1,
+  "version": "1.4.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "node-segfault-handler",
+      "version": "1.4.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.17.0"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    }
+  },
   "dependencies": {
     "bindings": {
       "version": "1.5.0",
@@ -18,9 +47,9 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-segfault-handler",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A C++ Node.js module that helps gathering informations on segmentation fault",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Shiranuit/node-segfault-handler#readme",
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.15.0"
+    "nan": "^2.17.0"
   },
   "files": [
     "index.d.ts",

--- a/src/backtrace.cc
+++ b/src/backtrace.cc
@@ -61,6 +61,11 @@ void Backtrace::PrintNative(FILE *file) {
  * Print V8 stack trace of isolated context.
  */ 
 void Backtrace::PrintV8(v8::Isolate *isolate, FILE *file) {
+  if (isolate == nullptr) {
+    fprintf(file, "Cannot print V8 stacktraces: Isolate is null\n");
+    return;
+  }
+
   // Retrieve current stacktraces from isolate
   v8::Local<v8::StackTrace> traces = v8::StackTrace::CurrentStackTrace(isolate, 255);
   for (int i = 0; i < traces->GetFrameCount(); i++) {


### PR DESCRIPTION
Better support for different NodeJS versions

Officially supported NodeJS versions:
- V12
- V14
- V16
- V18
- V19 (Temporary, until V20 is released)